### PR TITLE
Add support for BodoSQL Engine

### DIFF
--- a/pydough-analytics/README.md
+++ b/pydough-analytics/README.md
@@ -10,7 +10,7 @@ Community Edition toolkit that combines the PyDough DSL with LLM-based prompting
 
 ## Provider Setup — Env (Vertex vs API‑Key)
 
-Below are concise **`.env` examples** reflecting the two modes we support and a variant with explicit region.  
+Below are concise **`.env` examples** reflecting the two modes we support and a variant with explicit region.
 > **Do not commit real credentials or API keys to Git.** Use placeholders in docs and local `.env` files.
 
 ---
@@ -39,7 +39,7 @@ GOOGLE_GENAI_USE_VERTEXAI=true
 
 ### 2) API‑Key mode (no Vertex) — *Gemini only*
 
-If you set `GOOGLE_GENAI_USE_VERTEXAI=false`, the code will use the **Google AI Studio (API‑key) SDK** for Gemini.  
+If you set `GOOGLE_GENAI_USE_VERTEXAI=false`, the code will use the **Google AI Studio (API‑key) SDK** for Gemini.
 In this mode, `GOOGLE_API_KEY` is **required**, and ADC / project / region are **not used** by the Gemini client.
 
 ```bash
@@ -85,7 +85,7 @@ GOOGLE_GENAI_USE_VERTEXAI=true
 
 ## Using Local Models (Ollama)
 
-PyDough-CE can also be used with **locally hosted open-source models via Ollama**.  
+PyDough-CE can also be used with **locally hosted open-source models via Ollama**.
 However, it’s important to note that **results may vary and are not fully standardized** when using local models.
 
 The current PyDough prompting strategy and DSL generation were primarily designed and optimized for **high-performing hosted models**, specifically **Gemini 2.5 Pro** and **Anthropic Claude (Opus / Sonnet)**. As a result, local models may occasionally produce PyDough code that is syntactically close but semantically incorrect (for example, small naming mismatches or invalid expressions).
@@ -126,7 +126,7 @@ export OLLAMA_CONTEXT_LENGTH=32768
 
 ### Recommendation
 
-For the most reliable and consistent results, we recommend using **Gemini 2.5 Pro** or **Anthropic Claude Opus 4**.  
+For the most reliable and consistent results, we recommend using **Gemini 2.5 Pro** or **Anthropic Claude Opus 4**.
 Local models via Ollama are supported, but should be considered **experimental** at this time.
 
 ## TPCH sample database (download helper)
@@ -168,9 +168,9 @@ Invoke-WebRequest -Uri https://github.com/lovasoa/TPCH-sqlite/releases/download/
 
 ## Quick Guide
 
-### **Terminal location:** 
+### **Terminal location:**
 
-Run all of the next commands **from the `pydough-analytics` folder** (the folder that contains `data/`, `docs/`, `samples/`, `src/`, etc.).  
+Run all of the next commands **from the `pydough-analytics` folder** (the folder that contains `data/`, `docs/`, `samples/`, `src/`, etc.).
  Quick check:
  ```bash
  ls data
@@ -250,14 +250,14 @@ Each connection string must include all required parameters (user, password, hos
 
 ### SQLite
 
-Used for local files or in-memory databases.    
+Used for local files or in-memory databases.
 All values are required in the URL format.
 
 ```bash
 sqlite:///path/to/mydb.db
 ```
 
-- Uses a local .sqlite or .db file.      
+- Uses a local .sqlite or .db file.
 
 To use an in-memory database (for testing):
 
@@ -267,7 +267,7 @@ sqlite:///:memory:
 
 ### Snowflake
 
-Used for analytical data warehouses.      
+Used for analytical data warehouses.
 The connection string must include credentials, account, database, schema, and warehouse.
 
 ```bash
@@ -284,9 +284,9 @@ snowflake://user:password@account/db/schema?warehouse=WH&role=PUBLIC
 
 ### MySQL
 
-Used for transactional databases.   
-The URL must include user, password, host, port, and database.    
-Internally converted to mysql+mysqlconnector://.    
+Used for transactional databases.
+The URL must include user, password, host, port, and database.
+Internally converted to mysql+mysqlconnector://.
 
 ```bash
 mysql://user:password@host:port/mydb
@@ -307,9 +307,9 @@ mysql+mysqlconnector://user:password@host:port/mydb
 
 ### PostgreSQL
 
-Used for relational and analytical databases.   
-The URL must include all connection details.    
-Internally converted to postgresql+psycopg2://.   
+Used for relational and analytical databases.
+The URL must include all connection details.
+Internally converted to postgresql+psycopg2://.
 
 ```bash
 postgres://user:password@host:port/mydb
@@ -327,6 +327,32 @@ postgresql+psycopg2://user:password@host:port/mydb
 - `host`: Server hostname or IP address.
 - `port`: Port number (default: 5432).
 - `mydb`: Database name.
+
+### BodoSQL
+
+A high performance SQL engine that can query a variety of data sources.
+Currently, the BodoSQL backend is only available through the Python API.
+To use this backend, pass a [BodoSQLContext](https://docs.bodo.ai/latest/api_docs/sql/bodosqlcontext/) to `LLMClient.ask()`
+
+For example, the following code assumes TPCH data was written in [Iceberg table format](https://iceberg.apache.org/) to a local directory:
+``` py
+import os
+import pandas as pd
+from bodosql import BodoSQLContext, FileSystemCatalog
+
+catalog = FileSystemCatalog(os.path.abspath("./data/databases/tpch_db"))
+bc = BodoSQLContext(catalog=catalog)
+
+result = client.ask(
+    bodosql_context=bc
+    question="What are the most common transaction statuses and their respective counts?",
+    kg_path="./data/metadata/tpch_graph.json",           # Knowledge Graph JSON
+    md_path="./data/metadata_markdowns/tpch.md",         # Markdown doc for the DB
+    db_name="TPCH"
+)
+```
+
+For a complete list of supported database catalogs [see here](https://docs.bodo.ai/latest/api_docs/sql/database_catalogs/).
 
 ## MCP Server (Optional)
 
@@ -381,10 +407,10 @@ See more on the README_MCP.md under the mcp folder.
 ### Environment Variables
 
 The MCP server uses the same environment configuration as the CLI:
-- `GOOGLE_PROJECT_ID`, `GOOGLE_REGION`, and `GOOGLE_APPLICATION_CREDENTIALS` — for Vertex/Claude/Gemini clients.  
-- `GEMINI_API_KEY` or `ANTHROPIC_API_KEY` — if using direct SDK mode.  
+- `GOOGLE_PROJECT_ID`, `GOOGLE_REGION`, and `GOOGLE_APPLICATION_CREDENTIALS` — for Vertex/Claude/Gemini clients.
+- `GEMINI_API_KEY` or `ANTHROPIC_API_KEY` — if using direct SDK mode.
 
-When metadata is passed inline (instead of via `metadata_path`), it’s persisted temporarily in  
+When metadata is passed inline (instead of via `metadata_path`), it’s persisted temporarily in
 `/tmp/pydough_analytics_mcp/` and automatically deleted when `close_session()` is called.
 
 ---
@@ -433,51 +459,51 @@ pydough-analytics/
 ## Architecture Overview
 
 ```
-+-----------------------------+                               
-| CLI (Typer)                 |                               
-| (generate-json, generate-md,|                               
-|  ask)                       |                               
-+-------------+---------------+                               
-              |                                               
-              v                                               
-+-----------------------------+       +---------------------------+       
-| Metadata Generator          | ----> | Metadata JSON             |       
-| (SQLAlchemy inspector +     |       | (graph definition, V2)    |       
-|  identifier sanitizer,      |       +---------------------------+       
-|  type mapping)              |                                               
-+-------------+---------------+                                               
-              |                                               
-              v                                               
-+-----------------------------+       +---------------------------+       
-| Markdown Exporter           | ----> | Markdown Docs             |       
-| (render schema from graph)  |       | (human-readable overview) |       
-+-------------+---------------+       +---------------------------+       
++-----------------------------+
+| CLI (Typer)                 |
+| (generate-json, generate-md,|
+|  ask)                       |
++-------------+---------------+
+              |
+              v
++-----------------------------+       +---------------------------+
+| Metadata Generator          | ----> | Metadata JSON             |
+| (SQLAlchemy inspector +     |       | (graph definition, V2)    |
+|  identifier sanitizer,      |       +---------------------------+
+|  type mapping)              |
++-------------+---------------+
+              |
+              v
++-----------------------------+       +---------------------------+
+| Markdown Exporter           | ----> | Markdown Docs             |
+| (render schema from graph)  |       | (human-readable overview) |
++-------------+---------------+       +---------------------------+
 
               |
               v
-+-----------------------------+       +---------------------------+       
-| Ask Command (Typer)         | ----> | LLM Client                |       
-| (natural language question) |       | (prompt + schema + guide) |       
-+-------------+---------------+       +-------------+-------------+       
-              |                                                    
-              v                                                    
-+-----------------------------+       +---------------------------+       
-| AI Providers                | ----> | Gemini / Claude / aisuite |       
-| (google, anthropic,         |       |                           |       
-|  other via aisuite)         |       +---------------------------+       
-+-------------+---------------+                                      
-              |                                                    
-              v                                                    
-+-----------------------------+       +---------------------------+       
-| PyDough Executor            | ----> | SQL + DataFrame           |       
-| (extract code, run on DB,   |       | (results + explanation)   |       
-|  sanitize, retry on errors) |       +---------------------------+       
-+-------------+---------------+                                            
++-----------------------------+       +---------------------------+
+| Ask Command (Typer)         | ----> | LLM Client                |
+| (natural language question) |       | (prompt + schema + guide) |
++-------------+---------------+       +-------------+-------------+
+              |
+              v
++-----------------------------+       +---------------------------+
+| AI Providers                | ----> | Gemini / Claude / aisuite |
+| (google, anthropic,         |       |                           |
+|  other via aisuite)         |       +---------------------------+
++-------------+---------------+
+              |
+              v
++-----------------------------+       +---------------------------+
+| PyDough Executor            | ----> | SQL + DataFrame           |
+| (extract code, run on DB,   |       | (results + explanation)   |
+|  sanitize, retry on errors) |       +---------------------------+
++-------------+---------------+
               |
               v
 +-----------------------------+       +---------------------------+
 | MCP Server (FastMCP)        | ----> | External Clients (MCP)    |
-| (tools + resources:         |       | Inspector / Claude / IDEs | 
+| (tools + resources:         |       | Inspector / Claude / IDEs |
 |  init_metadata, ask, etc.)  |       |                           |
 +-----------------------------+       +---------------------------+
 

--- a/pydough-analytics/README.md
+++ b/pydough-analytics/README.md
@@ -330,11 +330,11 @@ postgresql+psycopg2://user:password@host:port/mydb
 
 ### BodoSQL
 
-A high performance SQL engine that can query a variety of data sources.
+A high performance SQL engine that can connect to a variety of data sources.
 Currently, the BodoSQL backend is only available through the Python API.
 To use this backend, pass a [BodoSQLContext](https://docs.bodo.ai/latest/api_docs/sql/bodosqlcontext/) to `LLMClient.ask()`.
 
-For example, the following code assumes TPCH data was written in [Iceberg table format](https://iceberg.apache.org/) to a local directory:
+For example, the following code assumes TPCH data was written in [Apache Iceberg table format](https://iceberg.apache.org/) to a local directory:
 ``` py
 import os
 import pandas as pd

--- a/pydough-analytics/README.md
+++ b/pydough-analytics/README.md
@@ -332,7 +332,7 @@ postgresql+psycopg2://user:password@host:port/mydb
 
 A high performance SQL engine that can query a variety of data sources.
 Currently, the BodoSQL backend is only available through the Python API.
-To use this backend, pass a [BodoSQLContext](https://docs.bodo.ai/latest/api_docs/sql/bodosqlcontext/) to `LLMClient.ask()`
+To use this backend, pass a [BodoSQLContext](https://docs.bodo.ai/latest/api_docs/sql/bodosqlcontext/) to `LLMClient.ask()`.
 
 For example, the following code assumes TPCH data was written in [Iceberg table format](https://iceberg.apache.org/) to a local directory:
 ``` py
@@ -352,7 +352,7 @@ result = client.ask(
 )
 ```
 
-For a complete list of supported database catalogs [see here](https://docs.bodo.ai/latest/api_docs/sql/database_catalogs/).
+For a complete list of supported database catalogs, [see here](https://docs.bodo.ai/latest/api_docs/sql/database_catalogs/).
 
 ## MCP Server (Optional)
 

--- a/pydough-analytics/pyproject.toml
+++ b/pydough-analytics/pyproject.toml
@@ -61,6 +61,13 @@ notebooks = [
 mcp = [
   "fastmcp>=0.4.0"
 ]
+bodosql = [
+  "bodo>=2026.5",
+  "bodosql>=2026.5"
+]
+iceberg = [
+  "pyiceberg"
+]
 
 [project.urls]
 Repository = "https://github.com/bodo-ai/pydough-ce"

--- a/pydough-analytics/pyproject.toml
+++ b/pydough-analytics/pyproject.toml
@@ -66,7 +66,7 @@ bodosql = [
   "bodosql>=2026.5"
 ]
 iceberg = [
-  "pyiceberg"
+  "pyiceberg<0.11"
 ]
 
 [project.urls]

--- a/pydough-analytics/samples/llm_demo.ipynb
+++ b/pydough-analytics/samples/llm_demo.ipynb
@@ -20,10 +20,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
     "from dotenv import load_dotenv\n",
-    "\n",
     "load_dotenv(dotenv_path=\"../../.env\")\n",
-    "from pydough_analytics.llm.llm_client import LLMClient"
+    "from pydough_analytics.llm.llm_client import LLMClient "
    ]
   },
   {
@@ -47,8 +47,8 @@
    "outputs": [],
    "source": [
     "client = LLMClient(\n",
-    "    # provider=\"anthropic\",\n",
-    "    # model=\"claude-sonnet-4-5@20250929\"\n",
+    "    #provider=\"anthropic\",\n",
+    "    #model=\"claude-sonnet-4-5@20250929\"\n",
     ")"
    ]
   },
@@ -84,10 +84,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "kg_path = \"../data/metadata/Tpch_graph.json\"\n",
-    "md_path = \"../data/metadata_markdowns/Tpch.md\"\n",
-    "db_name = \"tpch\"\n",
-    "url = \"sqlite:///../data/databases/TPCH.db\"\n",
+    "kg_path  = \"../data/metadata/Tpch_graph.json\"\n",
+    "md_path  = \"../data/metadata_markdowns/Tpch.md\"\n",
+    "db_name  = \"tpch\"\n",
+    "url      = \"sqlite:///../data/databases/TPCH.db\"\n",
     "\n",
     "question = \"Give me the name of all the suppliers from the United States\"\n",
     "\n",
@@ -407,7 +407,7 @@
     "    url=url,\n",
     "    md_path=md_path,\n",
     "    db_name=db_name,\n",
-    "    question=\"For each of the 5 largest part sizes, find the part of that size with the highest retail price\",\n",
+    "    question=\"For each of the 5 largest part sizes, find the part of that size with the highest retail price\"\n",
     ")\n",
     "\n",
     "print(result.full_explanation)"
@@ -448,7 +448,7 @@
     "    url=url,\n",
     "    md_path=md_path,\n",
     "    db_name=db_name,\n",
-    "    context_data=None,\n",
+    "    context_data=None\n",
     ")"
    ]
   },
@@ -619,7 +619,7 @@
     "    url=url,\n",
     "    md_path=md_path,\n",
     "    db_name=db_name,\n",
-    "    question=\"Give me all the order prices, name the column total_price.\",\n",
+    "    question=\"Give me all the order prices, name the column total_price.\"\n",
     ")\n",
     "\n",
     "result.df"
@@ -644,7 +644,7 @@
    "source": [
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "df = result.df\n",
+    "df= result.df\n",
     "\n",
     "plt.figure(figsize=(10, 6))\n",
     "plt.hist(df[\"total_price\"], bins=20, edgecolor=\"black\", alpha=0.7)\n",
@@ -799,8 +799,11 @@
     "query = \"Find the names of all customers and the number of their orders placed in 1995 in Europe.\"\n",
     "\n",
     "result = client.ask(\n",
-    "    kg_path=kg_path, url=url, md_path=md_path, db_name=db_name, question=query\n",
-    ")\n",
+    "    kg_path=kg_path,\n",
+    "    url=url,\n",
+    "    md_path=md_path,\n",
+    "    db_name=db_name,\n",
+    "    question=query)\n",
     "\n",
     "print(result.full_explanation)\n",
     "result.df.head()"
@@ -917,15 +920,16 @@
     }
    ],
    "source": [
-    "discourse = client.discourse(\n",
-    "    result,\n",
-    "    \"Now, give me the ones who have an account balance greater than $700 and placed at least one order in that same year. \\\n",
-    "Sorted in descending order by the number of orders.\",\n",
-    ")\n",
+    "discourse = client.discourse(result, \n",
+    "\"Now, give me the ones who have an account balance greater than $700 and placed at least one order in that same year. \\\n",
+    "Sorted in descending order by the number of orders.\")\n",
     "\n",
     "result2 = client.ask(\n",
-    "    kg_path=kg_path, url=url, md_path=md_path, db_name=db_name, question=discourse\n",
-    ")\n",
+    "    kg_path=kg_path,\n",
+    "    url=url,\n",
+    "    md_path=md_path,\n",
+    "    db_name=db_name,\n",
+    "    question=discourse)\n",
     "\n",
     "print(result2.full_explanation)\n",
     "result2.df.head()"
@@ -1061,7 +1065,11 @@
     "query = \"List customers who ordered in 1996 but not in 1997 with a total spent of over $1000.\"\n",
     "\n",
     "result = client.ask(\n",
-    "    kg_path=kg_path, url=url, md_path=md_path, db_name=db_name, question=query\n",
+    "    kg_path=kg_path,\n",
+    "    url=url,\n",
+    "    md_path=md_path,\n",
+    "    db_name=db_name,\n",
+    "    question=query\n",
     ")\n",
     "\n",
     "print(result.full_explanation)\n",
@@ -1181,14 +1189,15 @@
     }
    ],
    "source": [
-    "discourse = client.discourse(\n",
-    "    result,\n",
-    "    \"Now, include the number of months since the last order and sort by total spent, highest first.\",\n",
-    ")\n",
+    "discourse = client.discourse(result,\n",
+    "\"Now, include the number of months since the last order and sort by total spent, highest first.\")\n",
     "\n",
     "result2 = client.ask(\n",
-    "    kg_path=kg_path, url=url, md_path=md_path, db_name=db_name, question=discourse\n",
-    ")\n",
+    "    kg_path=kg_path,\n",
+    "    url=url,\n",
+    "    md_path=md_path,\n",
+    "    db_name=db_name,\n",
+    "    question=discourse)\n",
     "\n",
     "print(result2.full_explanation)\n",
     "result2.df.head()"
@@ -1212,9 +1221,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "client.add_definition(\n",
-    "    \"Revenue is defined as the sum of quantity * extended_price * (1 - discount) * (1 + tax).\"\n",
-    ")"
+    "client.add_definition(\"Revenue is defined as the sum of quantity * extended_price * (1 - discount) * (1 + tax).\")"
    ]
   },
   {
@@ -1298,7 +1305,11 @@
     "query = \"Find the region with the highest revenue in 1996.\"\n",
     "\n",
     "result = client.ask(\n",
-    "    kg_path=kg_path, url=url, md_path=md_path, db_name=db_name, question=query\n",
+    "    kg_path=kg_path,\n",
+    "    url=url,\n",
+    "    md_path=md_path,\n",
+    "    db_name=db_name,\n",
+    "    question=query\n",
     ")\n",
     "\n",
     "print(result.full_explanation)\n",
@@ -1410,12 +1421,14 @@
     }
    ],
    "source": [
-    "discourse = client.discourse(\n",
-    "    result, \"Can you compare it now year over year in that region?\"\n",
-    ")\n",
+    "discourse = client.discourse(result, \"Can you compare it now year over year in that region?\")\n",
     "\n",
     "result2 = client.ask(\n",
-    "    kg_path=kg_path, url=url, md_path=md_path, db_name=db_name, question=discourse\n",
+    "    kg_path=kg_path,\n",
+    "    url=url,\n",
+    "    md_path=md_path,\n",
+    "    db_name=db_name,\n",
+    "    question=discourse\n",
     ")\n",
     "\n",
     "print(result2.full_explanation)\n",
@@ -1564,7 +1577,11 @@
     "query = \"Which 10 customers purchased the highest quantity of products during 1998?.\"\n",
     "\n",
     "result = client.ask(\n",
-    "    kg_path=kg_path, url=url, md_path=md_path, db_name=db_name, question=query\n",
+    "    kg_path=kg_path,\n",
+    "    url=url,\n",
+    "    md_path=md_path,\n",
+    "    db_name=db_name,\n",
+    "    question=query\n",
     ")\n",
     "\n",
     "print(result.full_explanation)\n",
@@ -1710,13 +1727,14 @@
     }
    ],
    "source": [
-    "discourse = client.discourse(\n",
-    "    result,\n",
-    "    \"\"\"Now take into account only the products that have \"green\" in their name\"\"\",\n",
-    ")\n",
+    "discourse = client.discourse(result, \"\"\"Now take into account only the products that have \"green\" in their name\"\"\")\n",
     "\n",
     "result2 = client.ask(\n",
-    "    kg_path=kg_path, url=url, md_path=md_path, db_name=db_name, question=discourse\n",
+    "    kg_path=kg_path,\n",
+    "    url=url,\n",
+    "    md_path=md_path,\n",
+    "    db_name=db_name,\n",
+    "    question=discourse\n",
     ")\n",
     "\n",
     "print(result2.full_explanation)\n",
@@ -1726,7 +1744,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "blog-demo-313",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
@@ -1740,7 +1758,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.13"
+   "version": "3.13.5"
   }
  },
  "nbformat": 4,

--- a/pydough-analytics/samples/llm_demo.ipynb
+++ b/pydough-analytics/samples/llm_demo.ipynb
@@ -20,10 +20,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
     "from dotenv import load_dotenv\n",
+    "\n",
     "load_dotenv(dotenv_path=\"../../.env\")\n",
-    "from pydough_analytics.llm.llm_client import LLMClient "
+    "from pydough_analytics.llm.llm_client import LLMClient"
    ]
   },
   {
@@ -47,8 +47,8 @@
    "outputs": [],
    "source": [
     "client = LLMClient(\n",
-    "    #provider=\"anthropic\",\n",
-    "    #model=\"claude-sonnet-4-5@20250929\"\n",
+    "    # provider=\"anthropic\",\n",
+    "    # model=\"claude-sonnet-4-5@20250929\"\n",
     ")"
    ]
   },
@@ -84,10 +84,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "kg_path  = \"../data/metadata/Tpch_graph.json\"\n",
-    "md_path  = \"../data/metadata_markdowns/Tpch.md\"\n",
-    "db_name  = \"tpch\"\n",
-    "url      = \"sqlite:///../data/databases/TPCH.db\"\n",
+    "kg_path = \"../data/metadata/Tpch_graph.json\"\n",
+    "md_path = \"../data/metadata_markdowns/Tpch.md\"\n",
+    "db_name = \"tpch\"\n",
+    "url = \"sqlite:///../data/databases/TPCH.db\"\n",
     "\n",
     "question = \"Give me the name of all the suppliers from the United States\"\n",
     "\n",
@@ -407,7 +407,7 @@
     "    url=url,\n",
     "    md_path=md_path,\n",
     "    db_name=db_name,\n",
-    "    question=\"For each of the 5 largest part sizes, find the part of that size with the highest retail price\"\n",
+    "    question=\"For each of the 5 largest part sizes, find the part of that size with the highest retail price\",\n",
     ")\n",
     "\n",
     "print(result.full_explanation)"
@@ -448,7 +448,7 @@
     "    url=url,\n",
     "    md_path=md_path,\n",
     "    db_name=db_name,\n",
-    "    context_data=None\n",
+    "    context_data=None,\n",
     ")"
    ]
   },
@@ -619,7 +619,7 @@
     "    url=url,\n",
     "    md_path=md_path,\n",
     "    db_name=db_name,\n",
-    "    question=\"Give me all the order prices, name the column total_price.\"\n",
+    "    question=\"Give me all the order prices, name the column total_price.\",\n",
     ")\n",
     "\n",
     "result.df"
@@ -644,7 +644,7 @@
    "source": [
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "df= result.df\n",
+    "df = result.df\n",
     "\n",
     "plt.figure(figsize=(10, 6))\n",
     "plt.hist(df[\"total_price\"], bins=20, edgecolor=\"black\", alpha=0.7)\n",
@@ -799,11 +799,8 @@
     "query = \"Find the names of all customers and the number of their orders placed in 1995 in Europe.\"\n",
     "\n",
     "result = client.ask(\n",
-    "    kg_path=kg_path,\n",
-    "    url=url,\n",
-    "    md_path=md_path,\n",
-    "    db_name=db_name,\n",
-    "    question=query)\n",
+    "    kg_path=kg_path, url=url, md_path=md_path, db_name=db_name, question=query\n",
+    ")\n",
     "\n",
     "print(result.full_explanation)\n",
     "result.df.head()"
@@ -920,16 +917,15 @@
     }
    ],
    "source": [
-    "discourse = client.discourse(result, \n",
-    "\"Now, give me the ones who have an account balance greater than $700 and placed at least one order in that same year. \\\n",
-    "Sorted in descending order by the number of orders.\")\n",
+    "discourse = client.discourse(\n",
+    "    result,\n",
+    "    \"Now, give me the ones who have an account balance greater than $700 and placed at least one order in that same year. \\\n",
+    "Sorted in descending order by the number of orders.\",\n",
+    ")\n",
     "\n",
     "result2 = client.ask(\n",
-    "    kg_path=kg_path,\n",
-    "    url=url,\n",
-    "    md_path=md_path,\n",
-    "    db_name=db_name,\n",
-    "    question=discourse)\n",
+    "    kg_path=kg_path, url=url, md_path=md_path, db_name=db_name, question=discourse\n",
+    ")\n",
     "\n",
     "print(result2.full_explanation)\n",
     "result2.df.head()"
@@ -1065,11 +1061,7 @@
     "query = \"List customers who ordered in 1996 but not in 1997 with a total spent of over $1000.\"\n",
     "\n",
     "result = client.ask(\n",
-    "    kg_path=kg_path,\n",
-    "    url=url,\n",
-    "    md_path=md_path,\n",
-    "    db_name=db_name,\n",
-    "    question=query\n",
+    "    kg_path=kg_path, url=url, md_path=md_path, db_name=db_name, question=query\n",
     ")\n",
     "\n",
     "print(result.full_explanation)\n",
@@ -1189,15 +1181,14 @@
     }
    ],
    "source": [
-    "discourse = client.discourse(result,\n",
-    "\"Now, include the number of months since the last order and sort by total spent, highest first.\")\n",
+    "discourse = client.discourse(\n",
+    "    result,\n",
+    "    \"Now, include the number of months since the last order and sort by total spent, highest first.\",\n",
+    ")\n",
     "\n",
     "result2 = client.ask(\n",
-    "    kg_path=kg_path,\n",
-    "    url=url,\n",
-    "    md_path=md_path,\n",
-    "    db_name=db_name,\n",
-    "    question=discourse)\n",
+    "    kg_path=kg_path, url=url, md_path=md_path, db_name=db_name, question=discourse\n",
+    ")\n",
     "\n",
     "print(result2.full_explanation)\n",
     "result2.df.head()"
@@ -1221,7 +1212,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "client.add_definition(\"Revenue is defined as the sum of quantity * extended_price * (1 - discount) * (1 + tax).\")"
+    "client.add_definition(\n",
+    "    \"Revenue is defined as the sum of quantity * extended_price * (1 - discount) * (1 + tax).\"\n",
+    ")"
    ]
   },
   {
@@ -1305,11 +1298,7 @@
     "query = \"Find the region with the highest revenue in 1996.\"\n",
     "\n",
     "result = client.ask(\n",
-    "    kg_path=kg_path,\n",
-    "    url=url,\n",
-    "    md_path=md_path,\n",
-    "    db_name=db_name,\n",
-    "    question=query\n",
+    "    kg_path=kg_path, url=url, md_path=md_path, db_name=db_name, question=query\n",
     ")\n",
     "\n",
     "print(result.full_explanation)\n",
@@ -1421,14 +1410,12 @@
     }
    ],
    "source": [
-    "discourse = client.discourse(result, \"Can you compare it now year over year in that region?\")\n",
+    "discourse = client.discourse(\n",
+    "    result, \"Can you compare it now year over year in that region?\"\n",
+    ")\n",
     "\n",
     "result2 = client.ask(\n",
-    "    kg_path=kg_path,\n",
-    "    url=url,\n",
-    "    md_path=md_path,\n",
-    "    db_name=db_name,\n",
-    "    question=discourse\n",
+    "    kg_path=kg_path, url=url, md_path=md_path, db_name=db_name, question=discourse\n",
     ")\n",
     "\n",
     "print(result2.full_explanation)\n",
@@ -1577,11 +1564,7 @@
     "query = \"Which 10 customers purchased the highest quantity of products during 1998?.\"\n",
     "\n",
     "result = client.ask(\n",
-    "    kg_path=kg_path,\n",
-    "    url=url,\n",
-    "    md_path=md_path,\n",
-    "    db_name=db_name,\n",
-    "    question=query\n",
+    "    kg_path=kg_path, url=url, md_path=md_path, db_name=db_name, question=query\n",
     ")\n",
     "\n",
     "print(result.full_explanation)\n",
@@ -1727,14 +1710,13 @@
     }
    ],
    "source": [
-    "discourse = client.discourse(result, \"\"\"Now take into account only the products that have \"green\" in their name\"\"\")\n",
+    "discourse = client.discourse(\n",
+    "    result,\n",
+    "    \"\"\"Now take into account only the products that have \"green\" in their name\"\"\",\n",
+    ")\n",
     "\n",
     "result2 = client.ask(\n",
-    "    kg_path=kg_path,\n",
-    "    url=url,\n",
-    "    md_path=md_path,\n",
-    "    db_name=db_name,\n",
-    "    question=discourse\n",
+    "    kg_path=kg_path, url=url, md_path=md_path, db_name=db_name, question=discourse\n",
     ")\n",
     "\n",
     "print(result2.full_explanation)\n",
@@ -1744,7 +1726,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "blog-demo-313",
    "language": "python",
    "name": "python3"
   },
@@ -1758,7 +1740,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.5"
+   "version": "3.13.13"
   }
  },
  "nbformat": 4,

--- a/pydough-analytics/src/pydough_analytics/llm/llm_client.py
+++ b/pydough-analytics/src/pydough_analytics/llm/llm_client.py
@@ -2,7 +2,11 @@ import re
 from datetime import datetime
 from pathlib import Path
 import pydough
-from ..utils.utils import extract_python_code, execute_code_and_extract_result, read_file
+from ..utils.utils import (
+    extract_python_code,
+    execute_code_and_extract_result,
+    read_file,
+)
 from ..utils.storage.file_service import load_markdown
 from .ai_providers import get_provider
 
@@ -10,12 +14,12 @@ from .ai_providers import get_provider
 # This class represents the result of an LLM query, encapsulating the code, explanation, DataFrame, exception, original question, and SQL output.
 class Result:
     def __init__(
-        self, 
+        self,
         pydough_code=None,
-        full_explanation=None, 
-        df=None, 
-        exception=None, 
-        original_question=None, 
+        full_explanation=None,
+        df=None,
+        exception=None,
+        original_question=None,
         sql_output=None,
     ):
         self.code = pydough_code
@@ -24,7 +28,7 @@ class Result:
         self.exception = exception
         self.original_question = original_question
         self.sql = sql_output
-        
+
     def to_dict(self):
         return {
             "code": self.code,
@@ -35,9 +39,18 @@ class Result:
             "original_question": self.original_question,
         }
 
+
 # This class serves as a client for interacting with an LLM to ask questions, handle discourse, and correct errors.
 class LLMClient:
-    def __init__(self, prompt=None, script=None, db_markdown_map=None, provider="google", model="gemini-2.5-pro", definitions=None):
+    def __init__(
+        self,
+        prompt=None,
+        script=None,
+        db_markdown_map=None,
+        provider="google",
+        model="gemini-2.5-pro",
+        definitions=None,
+    ):
         PKG = Path(__file__).resolve().parents[1]
         DATA_DIR = PKG / "data" / "prompts"
         prompt_path = prompt or (DATA_DIR / "prompt.md")
@@ -50,42 +63,85 @@ class LLMClient:
         self.definitions = definitions or []
 
     # This method asks a question to the LLM, formats the prompt, executes the code, and returns a Result object.
-    def ask(self, question, kg_path, md_path, db_name, url= "sqlite:///data/databases/TPCH.db", context_data=None, auto_correct=False, max_corrections=1, **kwargs):
+    def ask(
+        self,
+        question,
+        kg_path,
+        md_path,
+        db_name,
+        url=None,
+        bodosql_context=None,
+        context_data=None,
+        auto_correct=False,
+        max_corrections=1,
+        **kwargs,
+    ):
         result = Result(original_question=question)
+
+        if url and bodosql_context:
+            raise ValueError(
+                "Both 'url' and 'bodosql_context' provided. Please provide only one of them."
+            )
+        elif url is None and bodosql_context is None:
+            raise ValueError("Either 'url' or 'bodosql_context' must be provided.")
+        elif bodosql_context:
+            try:
+                import bodosql
+            except ImportError:
+                raise ImportError(
+                    "'bodosql_context' option was supplied but bodosql is not installed. "
+                    "Please install with `pip install bodosql`"
+                )
+
+            if not isinstance(bodosql_context, bodosql.BodoSQLContext):
+                raise ValueError(
+                    "The 'bodosql_context' must be an instance of bodosql.BodoSQLContext."
+                )
 
         try:
             md_content = load_markdown(md_path)
             self.db_markdown_map[db_name] = md_content
             client = get_provider(self.provider, self.model)
-            formatted_q, formatted_prompt = self.format_prompt(question, db_name, context_data)
+            formatted_q, formatted_prompt = self.format_prompt(
+                question, db_name, context_data
+            )
 
             response = client.ask(formatted_q, formatted_prompt, **kwargs)
-            raw_response = response[0] if isinstance(response, tuple) else response 
+            raw_response = response[0] if isinstance(response, tuple) else response
             extracted_code = extract_python_code(raw_response)
 
-            cleaned_explanation = re.sub(r"```python\n.*?```", "", raw_response, flags=re.DOTALL).strip()
-            pretty_explanation = "\n\n".join([line.strip() for line in cleaned_explanation.split("\n") if line.strip()])
-            
+            cleaned_explanation = re.sub(
+                r"```python\n.*?```", "", raw_response, flags=re.DOTALL
+            ).strip()
+            pretty_explanation = "\n\n".join(
+                [
+                    line.strip()
+                    for line in cleaned_explanation.split("\n")
+                    if line.strip()
+                ]
+            )
+
             result.code = extracted_code
             result.full_explanation = pretty_explanation
             result.df = None
             result.sql = None
-            
-            env = {"pydough": pydough, "datetime": datetime} 
+
+            env = {"pydough": pydough, "datetime": datetime}
 
             df, sql = execute_code_and_extract_result(
                 extracted_code,
                 env,
                 db_name=db_name,
                 url=url,
-                kg_path=kg_path
+                bodosql_context=bodosql_context,
+                kg_path=kg_path,
             )
-            
+
             result.df = df
             result.sql = sql
 
         except Exception as e:
-            result.exception = str(e) 
+            result.exception = str(e)
 
             if auto_correct and max_corrections > 0:
                 return self.correct(
@@ -97,7 +153,7 @@ class LLMClient:
                     context_data=context_data,
                     auto_correct=auto_correct,
                     max_corrections=max_corrections - 1,
-                    **kwargs
+                    **kwargs,
                 )
 
         return result
@@ -109,22 +165,32 @@ class LLMClient:
         try:
             self.db_markdown_map[db_name] = md_content
             client = get_provider(self.provider, self.model)
-            formatted_q, formatted_prompt = self.format_prompt(question, db_name, context_data)
+            formatted_q, formatted_prompt = self.format_prompt(
+                question, db_name, context_data
+            )
 
             response = client.ask(formatted_q, formatted_prompt, **kwargs)
-            raw_response = response[0] if isinstance(response, tuple) else response 
+            raw_response = response[0] if isinstance(response, tuple) else response
             extracted_code = extract_python_code(raw_response)
 
-            cleaned_explanation = re.sub(r"```python\n.*?```", "", raw_response, flags=re.DOTALL).strip()
-            pretty_explanation = "\n\n".join([line.strip() for line in cleaned_explanation.split("\n") if line.strip()])
-            
+            cleaned_explanation = re.sub(
+                r"```python\n.*?```", "", raw_response, flags=re.DOTALL
+            ).strip()
+            pretty_explanation = "\n\n".join(
+                [
+                    line.strip()
+                    for line in cleaned_explanation.split("\n")
+                    if line.strip()
+                ]
+            )
+
             result.code = extracted_code
             result.full_explanation = pretty_explanation
             result.df = None
             result.sql = None
 
         except Exception as e:
-            result.exception = str(e) 
+            result.exception = str(e)
 
         return result
 
@@ -144,7 +210,7 @@ class LLMClient:
             f"The dataframe generated was: {result.df}. Now, answer this follow-up question: '{follow_up}'. "
             f"IMPORTANT: If you need any of the above code, you must declare it again because it does not exist in memory."
         )
-        
+
     # This method adds a new definition to the LLM client, which can be used in prompts.
     def add_definition(self, new_definition):
         if new_definition:
@@ -154,30 +220,42 @@ class LLMClient:
     def correct(self, result, kg_path, url, md_path, db_name, context_data, **kwargs):
         if result.exception:
             try:
-                formatted_q, formatted_prompt = self.format_prompt(result.original_question, db_name, context_data)
+                formatted_q, formatted_prompt = self.format_prompt(
+                    result.original_question, db_name, context_data
+                )
                 corrective_question = (
                     f"An error occurred while processing this code: {result.code}. "
                     f"The error is: '{result.exception}'. The original question was: '{result.original_question}'. "
                     f"Can you help me fix the issue? Take into account the context: '{formatted_prompt}'."
                 )
-                return self.ask(corrective_question, db_name=db_name, kg_path=kg_path, url=url, md_path=md_path, context_data=context_data, **kwargs)
+                return self.ask(
+                    corrective_question,
+                    db_name=db_name,
+                    kg_path=kg_path,
+                    url=url,
+                    md_path=md_path,
+                    context_data=context_data,
+                    **kwargs,
+                )
             except Exception as e:
-                return Result(original_question=result.original_question, exception=str(e))
+                return Result(
+                    original_question=result.original_question, exception=str(e)
+                )
         return result
-    
+
     # This method formats the prompt for the LLM, including the question, database schema, and any additional context.
     def format_prompt(self, question, db_name, context_data):
         db_content = self.db_markdown_map.get(db_name, "")
         context = context_data or {}
         recommendation = context.get("context_id", "")
         similar_code = context.get("similar_queries", "")
-        redefined_question = context.get("redefined_question", question)    
+        redefined_question = context.get("redefined_question", question)
         formatted_q = f"{redefined_question}\nDatabase Schema:\n{str(db_content)}"
         formatted_prompt = self.prompt.format(
             script_content=self.script,
             database_content=str(db_content),
             similar_queries=similar_code,
             recomendation=recommendation,
-            definitions="".join(self.definitions)
+            definitions="".join(self.definitions),
         )
-        return formatted_q, formatted_prompt 
+        return formatted_q, formatted_prompt

--- a/pydough-analytics/src/pydough_analytics/llm/llm_client.py
+++ b/pydough-analytics/src/pydough_analytics/llm/llm_client.py
@@ -82,8 +82,6 @@ class LLMClient:
             raise ValueError(
                 "Both 'url' and 'bodosql_context' provided. Please provide only one of them."
             )
-        elif url is None and bodosql_context is None:
-            raise ValueError("Either 'url' or 'bodosql_context' must be provided.")
         elif bodosql_context:
             try:
                 import bodosql

--- a/pydough-analytics/src/pydough_analytics/llm/llm_client.py
+++ b/pydough-analytics/src/pydough_analytics/llm/llm_client.py
@@ -149,6 +149,7 @@ class LLMClient:
                     db_name=db_name,
                     kg_path=kg_path,
                     url=url,
+                    bodosql_context=bodosql_context,
                     md_path=md_path,
                     context_data=context_data,
                     auto_correct=auto_correct,
@@ -217,7 +218,7 @@ class LLMClient:
             self.definitions.append(new_definition)
 
     # This method corrects the result of a previous query if an exception occurred, reformulating the question to ask for help.
-    def correct(self, result, kg_path, url, md_path, db_name, context_data, **kwargs):
+    def correct(self, result, kg_path, url, bodosql_context, md_path, db_name, context_data, **kwargs):
         if result.exception:
             try:
                 formatted_q, formatted_prompt = self.format_prompt(
@@ -233,6 +234,7 @@ class LLMClient:
                     db_name=db_name,
                     kg_path=kg_path,
                     url=url,
+                    bodosql_context=bodosql_context,
                     md_path=md_path,
                     context_data=context_data,
                     **kwargs,

--- a/pydough-analytics/src/pydough_analytics/utils/utils.py
+++ b/pydough-analytics/src/pydough_analytics/utils/utils.py
@@ -89,7 +89,7 @@ def execute_code_and_extract_result(
     Execute a PyDough query using the provided environment, metadata and DB URL.
     The connection logic is dynamically configured per engine.
     """
-    if kg_path and db_name and url:
+    if kg_path and db_name and (url is not None or bodosql_context is not None):
         metadata: list = load_json(kg_path)
         graph: dict | None = next(
             (graph for graph in metadata if graph.get("name") == db_name), None

--- a/pydough-analytics/src/pydough_analytics/utils/utils.py
+++ b/pydough-analytics/src/pydough_analytics/utils/utils.py
@@ -9,12 +9,14 @@ import pydough
 from .storage.file_service import load_json
 from .database_connectors.connection_parser import parse_db_url
 
+
 def read_file(file_path):
     """
     Read a specific file from memory
     """
     with open(file_path, "r", encoding="utf-8") as file:
         return file.read()
+
 
 def extract_python_code(text):
     """
@@ -27,11 +29,14 @@ def extract_python_code(text):
     if matches:
         return textwrap.dedent(matches[-1]).strip()
 
-    answer_match: Match | None = re.search(r"Answer:\s*(.*)", text, flags=re.IGNORECASE | re.DOTALL)
+    answer_match: Match | None = re.search(
+        r"Answer:\s*(.*)", text, flags=re.IGNORECASE | re.DOTALL
+    )
     if answer_match:
         return answer_match.group(1).strip()
 
     return ""
+
 
 # ---- Connection map declaration----
 connection_map: dict[str, dict] = {
@@ -58,7 +63,7 @@ connection_map: dict[str, dict] = {
             "host": c["host"],
             "port": c.get("port", 3306),
             "database": c["database"],
-            },
+        },
     },
     "postgres": {
         "kwargs": lambda c: {
@@ -69,33 +74,53 @@ connection_map: dict[str, dict] = {
             "dbname": c["database"],
         },
     },
+    "bodosql": {
+        "kwargs": lambda c: {
+            "context": c["context"],
+        },
+    },
 }
 
 
-def execute_code_and_extract_result(code, env, kg_path=None, db_name=None, url=None):
+def execute_code_and_extract_result(
+    code, env, kg_path=None, db_name=None, url=None, bodosql_context=None
+):
     """
     Execute a PyDough query using the provided environment, metadata and DB URL.
     The connection logic is dynamically configured per engine.
     """
     if kg_path and db_name and url:
         metadata: list = load_json(kg_path)
-        graph: dict | None = next((graph for graph in metadata if graph.get("name") == db_name), None)
+        graph: dict | None = next(
+            (graph for graph in metadata if graph.get("name") == db_name), None
+        )
         if not graph:
-            raise ValueError(f"Graph with name '{db_name}' not found in metadata file: {kg_path}")
+            raise ValueError(
+                f"Graph with name '{db_name}' not found in metadata file: {kg_path}"
+            )
         with tempfile.NamedTemporaryFile(mode="w+", suffix=".json") as tmp:
             json.dump(metadata, tmp)
             tmp.flush()
             actual_graph_name: str = graph.get("name")
             pydough.active_session.load_metadata_graph(tmp.name, actual_graph_name)
-        
-        db_config: str = parse_db_url(url)
-        engine: str = db_config["engine"]
+
+        if bodosql_context:
+            db_config: dict = {"context": bodosql_context}
+            engine: str = "bodosql"
+        else:
+            assert url is not None, (
+                "URL must be provided if bodosql_context is not used."
+            )
+            db_config: dict = parse_db_url(url)
+            engine: str = db_config["engine"]
 
         if engine not in connection_map:
             raise ValueError(f"Unsupported engine: {engine}")
-        
+
         conn_spec = connection_map[engine]
-        pydough.active_session.connect_database(engine, **conn_spec["kwargs"](db_config))
+        pydough.active_session.connect_database(
+            engine, **conn_spec["kwargs"](db_config)
+        )
 
     try:
         transformed = transform_cell(code, "pydough.active_session.metadata", set(env))
@@ -104,5 +129,5 @@ def execute_code_and_extract_result(code, env, kg_path=None, db_name=None, url=N
         df = pydough.to_df(last_variable)
         sql = pydough.to_sql(last_variable)
         return df, sql
-    except Exception as e:
+    except Exception:
         raise RuntimeError(f"Error executing PyDough code:\n{traceback.format_exc()}")

--- a/pydough-analytics/tests/test_llm_client.py
+++ b/pydough-analytics/tests/test_llm_client.py
@@ -1,6 +1,5 @@
 import pytest
 from unittest.mock import MagicMock
-from types import SimpleNamespace
 
 # Target under test
 from src.pydough_analytics.llm.llm_client import LLMClient, Result
@@ -10,6 +9,7 @@ from src.pydough_analytics.llm.llm_client import LLMClient, Result
 # Helpers
 # ---------------------------
 
+
 @pytest.fixture(autouse=True)
 def _patch_llmclient_default_prompt_read(mocker):
     """
@@ -17,15 +17,18 @@ def _patch_llmclient_default_prompt_read(mocker):
     """
     mocker.patch(
         "src.pydough_analytics.llm.llm_client.read_file",
-        return_value="DUMMY_PROMPT_CONTENT"
+        return_value="DUMMY_PROMPT_CONTENT",
     )
+
 
 class FakeDF:
     """
     Minimal DataFrame-like object for serialization tests.
     """
+
     def __init__(self, rows):
         self._rows = rows
+
     def to_dict(self, orient="records"):
         assert orient == "records"
         return self._rows
@@ -34,6 +37,7 @@ class FakeDF:
 # ---------------------------
 # Result.to_dict
 # ---------------------------
+
 
 def test_result_to_dict_serializes_df():
     """
@@ -46,7 +50,7 @@ def test_result_to_dict_serializes_df():
         df=df,
         exception=None,
         original_question="Q",
-        sql_output="SELECT 1"
+        sql_output="SELECT 1",
     )
     out = r.to_dict()
     assert out["code"] == "x=1"
@@ -61,6 +65,7 @@ def test_result_to_dict_serializes_df():
 # LLMClient.ask (happy path) - provider returns TEXT
 # ---------------------------
 
+
 def test_llmclient_ask_happy_text_only(mocker):
     """
     ask(): extracts python code, executes, and returns Result with df/sql and explanation cleaned.
@@ -68,7 +73,10 @@ def test_llmclient_ask_happy_text_only(mocker):
     # read_file for prompt & script
     mocker.patch(
         "src.pydough_analytics.llm.llm_client.read_file",
-        side_effect=["PROMPT {script_content} {database_content} {similar_queries} {recomendation} {definitions}", "SCRIPTX"],
+        side_effect=[
+            "PROMPT {script_content} {database_content} {similar_queries} {recomendation} {definitions}",
+            "SCRIPTX",
+        ],
     )
     # markdown load
     mocker.patch(
@@ -96,6 +104,7 @@ def test_llmclient_ask_happy_text_only(mocker):
 
     c = LLMClient(provider="google", model="gemini")
     res = c.ask(
+        url="sqlite:///dummy.db",
         question="How many rows?",
         kg_path="graph.json",
         md_path="docs.md",
@@ -118,6 +127,7 @@ def test_llmclient_ask_happy_text_only(mocker):
 # ---------------------------
 # LLMClient.ask (happy path) - provider returns (TEXT, usage)
 # ---------------------------
+
 
 def test_llmclient_ask_happy_tuple_response(mocker):
     """
@@ -148,7 +158,8 @@ def test_llmclient_ask_happy_tuple_response(mocker):
 
     c = LLMClient(provider="google", model="gemini")
     res = c.ask(
-        "Q",
+        url="sqlite:///dummy.db",
+        question="Q",
         kg_path="kg.json",
         md_path="md.md",
         db_name="DB",
@@ -163,6 +174,7 @@ def test_llmclient_ask_happy_tuple_response(mocker):
 # ---------------------------
 # LLMClient.ask (error path) - no auto-correct
 # ---------------------------
+
 
 def test_llmclient_ask_exception_no_autocorrect(mocker):
     """
@@ -192,7 +204,14 @@ def test_llmclient_ask_exception_no_autocorrect(mocker):
     )
 
     c = LLMClient()
-    res = c.ask("Q?", kg_path="kg", md_path="md", db_name="DB", auto_correct=False)
+    res = c.ask(
+        url="sqlite:///dummy.db",
+        question="Q?",
+        kg_path="kg",
+        md_path="md",
+        db_name="DB",
+        auto_correct=False,
+    )
     assert isinstance(res, Result)
     assert res.exception is not None
     assert "exec failed" in res.exception
@@ -201,6 +220,7 @@ def test_llmclient_ask_exception_no_autocorrect(mocker):
 # ---------------------------
 # LLMClient.ask (error path) - WITH auto-correct
 # ---------------------------
+
 
 def test_llmclient_ask_exception_with_autocorrect_calls_correct(mocker):
     """
@@ -235,7 +255,8 @@ def test_llmclient_ask_exception_with_autocorrect_calls_correct(mocker):
     mocker.patch.object(c, "correct", return_value=sentinel)
 
     res = c.ask(
-        "Q",
+        url="sqlite:///dummy.db",
+        question="Q",
         kg_path="kg",
         md_path="md",
         db_name="DB",
@@ -252,6 +273,7 @@ def test_llmclient_ask_exception_with_autocorrect_calls_correct(mocker):
 # ---------------------------
 # LLMClient.simple_ask
 # ---------------------------
+
 
 def test_llmclient_simple_ask_happy_text_only(mocker):
     """
@@ -409,6 +431,7 @@ def test_llmclient_simple_ask_exception(mocker):
 # LLMClient.discourse
 # ---------------------------
 
+
 def test_discourse_no_result_returns_followup():
     """
     discourse(): if result is falsy, returns follow-up unchanged.
@@ -445,6 +468,7 @@ def test_discourse_with_code_and_df():
 # LLMClient.add_definition
 # ---------------------------
 
+
 def test_add_definition_appends():
     """
     add_definition(): append non-empty definitions.
@@ -458,6 +482,7 @@ def test_add_definition_appends():
 # ---------------------------
 # LLMClient.format_prompt
 # ---------------------------
+
 
 def test_format_prompt_uses_map_and_context(mocker):
     """
@@ -503,6 +528,7 @@ def test_format_prompt_uses_map_and_context(mocker):
 # LLMClient.correct
 # ---------------------------
 
+
 def test_correct_calls_ask_with_corrective_question(mocker):
     """
     correct(): builds a corrective prompt and delegates back to ask().
@@ -518,7 +544,9 @@ def test_correct_calls_ask_with_corrective_question(mocker):
     sentinel = Result(pydough_code="fixed", original_question="orig")
     mocker.patch.object(c, "ask", return_value=sentinel)
 
-    r = Result(pydough_code="x=1", original_question="orig", exception="ZeroDivisionError")
+    r = Result(
+        pydough_code="x=1", original_question="orig", exception="ZeroDivisionError"
+    )
     out = c.correct(
         result=r,
         kg_path="kg",

--- a/pydough-analytics/tests/test_llm_client.py
+++ b/pydough-analytics/tests/test_llm_client.py
@@ -551,6 +551,7 @@ def test_correct_calls_ask_with_corrective_question(mocker):
         result=r,
         kg_path="kg",
         url="sqlite:///dummy.db",
+        bodosql_context=None,
         md_path="md",
         db_name="DB",
         context_data={"x": 1},

--- a/pydough-analytics/tests/test_llm_client.py
+++ b/pydough-analytics/tests/test_llm_client.py
@@ -1,3 +1,4 @@
+import pydough
 import pytest
 from unittest.mock import MagicMock
 
@@ -268,6 +269,75 @@ def test_llmclient_ask_exception_with_autocorrect_calls_correct(mocker):
     # Ensure max_corrections was decremented (verified via call kwargs)
     kwargs = c.correct.call_args.kwargs
     assert kwargs.get("max_corrections") == 1
+
+
+# ---------------------------
+# LLMClient.ask with BodoSQL context
+# ---------------------------
+
+
+def test_llmclient_ask_with_bodosql_context(mocker, tmp_path):
+    """
+    Test ask() with BodoSQLContext and verify Pydough connects to the database. 
+    """
+    try:
+        from bodosql import BodoSQLContext
+    except ImportError:
+        pytest.skip("bodosql not installed, skipping")
+
+    mocker.patch(
+        "src.pydough_analytics.llm.llm_client.read_file",
+        side_effect=["PROMPT", "SCRIPT"],
+    )
+    mocker.patch(
+        "src.pydough_analytics.llm.llm_client.load_markdown",
+        return_value="MD",
+    )
+    spy = mocker.spy(pydough.active_session, "connect_database")
+
+    # Create an empty metadata graph file
+    db_name = "BodoSQLTestDB"
+    kg_path = tmp_path / "kg.json"
+    with open(kg_path, "w") as f:
+        f.write(f"""
+        [
+            {{
+                "name": "{db_name}",
+                "version": "V2",
+                "collections": [],
+                "relationships": []
+            }}
+        ]
+        """)
+    pydough_code = f"x={db_name}.CALCULATE(1)"
+
+    fake_provider = MagicMock()
+    fake_provider.ask.return_value = f"```python\n{pydough_code}\n```"
+    mocker.patch(
+        "src.pydough_analytics.llm.llm_client.get_provider",
+        return_value=fake_provider,
+    )
+
+    mocker.patch(
+        "src.pydough_analytics.llm.llm_client.extract_python_code",
+        return_value=pydough_code,
+    )
+
+    bc = BodoSQLContext()
+
+    c = LLMClient()
+    result = c.ask(
+        question="Q",
+        kg_path=kg_path,
+        md_path="md.md",
+        db_name=db_name,
+        bodosql_context=bc,
+    )
+
+    assert result.code == pydough_code
+    assert result.exception is None
+    assert result.df is not None
+    assert spy.call_count == 1
 
 
 # ---------------------------


### PR DESCRIPTION
## Description

This PR adds support for passing a BodoSQL context to the LLM Client, enabling question answering over data stored in Iceberg tables. It also adds BodoSQL and Iceberg as optional dependencies. 

Additional caveats/followups
* CLI support is not currently included, since BodoSQL supports several different catalog types and arguments.

* Metadata generation is also not currently included since in general BodoSQL/Iceberg tables don't have primary/foreign keys, making relationships between tables difficult to infer. 

## Example usage:

``` shell
pip install pydough-analytics[bodosql,iceberg]
```

``` python
iceberg_warehouse = "/tmp/iceberg_warehouse"
catalog = FileSystemCatalog(iceberg_warehouse)
bc = BodoSQLContext(catalog=catalog)

client = LLMClient(...)

result = client.ask(
    question=...,
    kg_path=...,
    md_path=...,
    db_name=...,
    bodosql_context=bc,
)
```

For a full list of catalogs supported by BodoSQL, see: 
https://docs.bodo.ai/latest/api_docs/sql/database_catalogs/ 

