### PR TITLE
Fix sqlite absolute-path parsing and forward database_url to query execution

### DIFF
--- a/pydough-analytics/src/pydough_analytics/mcp/server.py
+++ b/pydough-analytics/src/pydough_analytics/mcp/server.py
@@ -29,8 +29,10 @@ class SessionData:
     metadata_markdown: str  # cached Markdown content
     db_name: str
     db_config: Dict[str, Any]
+    database_url: Optional[str]  # original URL, forwarded to execute_code_and_extract_result
     default_max_rows: int
     last_result: Optional[Result]
+    owns_files: bool = True  # False when kg_path points to a caller-supplied file
 
 
 _sessions: Dict[str, SessionData] = {}
@@ -177,8 +179,10 @@ async def open_session_impl(
         metadata_markdown=md_text,
         db_name=db_name,
         db_config=db_config,
+        database_url=database_url,
         default_max_rows=max_rows,
         last_result=None,
+        owns_files=metadata_path is None,  # only delete files we created ourselves
     )
     return {"session_id": session_id}
 
@@ -189,12 +193,13 @@ async def close_session_impl(*, session_id: str) -> Dict[str, Any]:
     if not data:
         raise ToolError(f"Session '{session_id}' not found")
 
-    for p in (data.kg_path, data.md_path):
-        try:
-            if p.exists():
-                p.unlink()
-        except Exception:
-            logger.debug("Failed to remove temporary file: %s", p, exc_info=True)
+    if data.owns_files:
+        for p in (data.kg_path, data.md_path):
+            try:
+                if p.exists():
+                    p.unlink()
+            except Exception:
+                logger.debug("Failed to remove temporary file: %s", p, exc_info=True)
 
     return {"closed": True}
 
@@ -218,6 +223,7 @@ async def ask_impl(
             kg_path=str(session.kg_path),
             md_path=str(session.md_path),
             db_name=session.db_name,
+            url=session.database_url,
             auto_correct=auto_correct,
             max_corrections=max_corrections,
             **(provider_params or {}),

--- a/pydough-analytics/src/pydough_analytics/utils/database_connectors/connection_parser.py
+++ b/pydough-analytics/src/pydough_analytics/utils/database_connectors/connection_parser.py
@@ -34,11 +34,15 @@ def parse_db_url(url: str) -> dict:
 @register_parser("sqlite")
 def parse_sqlite(parsed: ParseResult) -> dict:
     """
-    Example: sqlite:///path/to/file.db
+    Example: sqlite:///relative/path.db  or  sqlite:////absolute/path.db
     """
+    path = parsed.path
+    # 4-slash URLs (sqlite:////abs/path) → path starts with "//" → absolute path
+    # 3-slash URLs (sqlite:///rel/path)  → path starts with "/"  → relative path
+    database = path[1:] if path.startswith("//") else path.lstrip("/")
     return {
         "engine": "sqlite",
-        "database": parsed.path.lstrip("/"),
+        "database": database,
     }
 
 # Parser for Snowflake


### PR DESCRIPTION
### Two small fixes found while using the MCP server against a sqlite database.

_**1. SQLite absolute paths are mangled by the URL parser**_

In connection_parser.py, parse_sqlite did parsed.path.lstrip("/"). For a 4-slash absolute URL (sqlite:////abs/path) the parsed path is //abs/path, and lstrip("/") removes both leading slashes, turning the absolute path into a relative one. The database file then can't be found.

**Fix:** detect the 4-slash case (path starts with //) and remove only the first slash, preserving the absolute path. 3-slash relative URLs are unchanged.

_**2. database_url is not forwarded to query execution**_

In the MCP server, open_session_impl received a database_url but did not store it, so ask_impl never passed it to client.ask(). Queries therefore ran against the default connection rather than the one the caller specified.

**Fix:** store the original database_url on SessionData and pass it as url= in ask_impl.

(While here, I also guarded temp-file cleanup so close_session only deletes kg_path/md_path when the session created them, via an owns_files flag. If a caller supplies their own metadata_path, that file is theirs and shouldn't be deleted on close. Happy to split this into its own PR if you'd prefer.)